### PR TITLE
Use "friendly" file names in the cache directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ overriden using command line options:
         -s, --storage [path]  Storage path
         -x, --proxy           HTTP proxy to be used, e.g. http://user:pass@example.com:8888/
         -e, --expired         Use expired cache when npm registry unavailable
+        -f, --friendly-names  Use actual file names instead of hashes in the cache
         -v, --verbose         Verbose mode
             --help            This help
 

--- a/bin/npm-proxy-cache
+++ b/bin/npm-proxy-cache
@@ -12,6 +12,7 @@ program
   .option('-s, --storage [path]', 'Storage path', __dirname + '/../cache')
   .option('-x, --proxy [address]', 'HTTP proxy to be used, e.g. http://user:pass@example.com:8888/')
   .option('-e, --expired', 'Use expired cache when npm registry unavailable')
+  .option('-f, --friendly-names', 'Use actual file names instead of hashes in the cache')
   .option('-v, --verbose', 'Verbose mode')
   .parse(process.argv);
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -83,7 +83,7 @@ function Cache(opts) {
 
 
   this.getPath = function(key) {
-    var file, base, dir;
+    var file, base, chunks, dir;
     if (this.opts.friendlyNames) {
       // The key is the URL; the last part is the module name and if
       // the last version is requested, it lacks the file extension
@@ -97,7 +97,12 @@ function Cache(opts) {
                  .substring(0, 8) + path.extname(key);
       base = file;
     }
-    dir = base.split('').splice(0, 3).join('/');
+    // Make sure that there are always 3 nested directories to avoid
+    // both file and folder at the same level (/q/q, /q/q/qq)
+    chunks = base.split('').splice(0, 3);
+    while (chunks.length < 3)
+      chunks.push('-');
+    dir = chunks.join('/');
 
     return {
       dir: path.join(this.opts.path, dir),

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -83,14 +83,21 @@ function Cache(opts) {
 
 
   this.getPath = function(key) {
-    // Use just the module name, if friendly names are requested; it
-    // lacks the file extension if the latest version is requested
-    var file = this.opts.friendlyNames ? path.basename(key) :
-                 crypto.createHash('md5').update(key).digest('hex')
-                     .substring(0, 8) + path.extname(key),
-    // Make sure that there was no dot in the first three characters
-    // of the module name, which are used in the directory structure
-        dir = file.split('').splice(0, 3).join('/').replace(/\./g, '-');
+    var file, base, dir;
+    if (this.opts.friendlyNames) {
+      // The key is the URL; the last part is the module name and if
+      // the last version is requested, it lacks the file extension
+      file = path.basename(key);
+      // Cut the version suffix and file extension; only module name
+      // should make the directory, make sure that there is no dot as
+      // directory name coming from the first characters of the fike name
+      base = file.replace(/(-\d\.\d.\d)?\.tgz/, '').replace(/\./g, '-');
+    } else {
+      file = crypto.createHash('md5').update(key).digest('hex')
+                 .substring(0, 8) + path.extname(key);
+      base = file;
+    }
+    dir = base.split('').splice(0, 3).join('/');
 
     return {
       dir: path.join(this.opts.path, dir),

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -8,6 +8,7 @@ function Cache(opts) {
 
   this.opts = opts || {}
   this.opts.ttl = (opts.ttl || 1800) * 1000;
+  this.opts.friendlyNames = opts.friendlyNames;
   this.opts.path = opts.path || __dirname + '/../cache';
 
   this.locks = {};
@@ -82,8 +83,14 @@ function Cache(opts) {
 
 
   this.getPath = function(key) {
-    var file = crypto.createHash('md5').update(key).digest('hex').substring(0, 8) + path.extname(key),
-      dir = file.split('').splice(0, 3).join('/');
+    // Use just the module name, if friendly names are requested; it
+    // lacks the file extension if the latest version is requested
+    var file = this.opts.friendlyNames ? path.basename(key) :
+                 crypto.createHash('md5').update(key).digest('hex')
+                     .substring(0, 8) + path.extname(key),
+    // Make sure that there was no dot in the first three characters
+    // of the module name, which are used in the directory structure
+        dir = file.split('').splice(0, 3).join('/').replace(/\./g, '-');
 
     return {
       dir: path.join(this.opts.path, dir),

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -29,7 +29,9 @@ exports.powerup = function(opts) {
     cert: fs.readFileSync(__dirname + '/../cert/dummy.crt', 'utf8')
   };
 
-  this.cache = new Cache({path: opts.storage, ttl: opts.ttl});
+  this.cache = new Cache({
+    path: opts.storage, ttl: opts.ttl, friendlyNames: opts.friendlyNames
+  });
 
   this.log = log4js.getLogger('proxy');
   this.log.setLevel(opts.verbose ? 'DEBUG' : 'INFO');

--- a/test/cache.js
+++ b/test/cache.js
@@ -86,6 +86,63 @@ describe('cache', function() {
       assert.equal(path.full, opts.path + '/f/a/7/fa7bf9eb.tgz');
       assert.equal(path.rel, 'f/a/7/fa7bf9eb.tgz');
     });
+
+    describe ('given the friendlyNames option is set', function () {
+      var cache;
+
+      beforeEach(function() {
+        opts.friendlyNames = true;
+        cache = new Cache(opts);
+      });
+
+      it('uses just the module name from the URL', function () {
+        var path = cache.getPath('http://registry/test');
+        assert.equal(path.dir, opts.path + '/t/e/s');
+        assert.equal(path.file, 'test');
+        assert.equal(path.full, opts.path + '/t/e/s/test');
+        assert.equal(path.rel, 't/e/s/test');
+      });
+
+      it('cuts the file extension from the module URL', function () {
+        var path = cache.getPath('http://registry/test.tgz');
+        assert.equal(path.dir, opts.path + '/t/e/s');
+        assert.equal(path.file, 'test.tgz');
+        assert.equal(path.full, opts.path + '/t/e/s/test.tgz');
+        assert.equal(path.rel, 't/e/s/test.tgz');
+      });
+
+      it('cuts the version suffix from the module URL', function () {
+        var path = cache.getPath('http://registry/test-1.2.3.tgz');
+        assert.equal(path.dir, opts.path + '/t/e/s');
+        assert.equal(path.file, 'test-1.2.3.tgz');
+        assert.equal(path.full, opts.path + '/t/e/s/test-1.2.3.tgz');
+        assert.equal(path.rel, 't/e/s/test-1.2.3.tgz');
+      });
+
+      it('uses hyphens instead of dots in the directory structure', function () {
+        var path = cache.getPath('http://registry/te.st');
+        assert.equal(path.dir, opts.path + '/t/e/-');
+        assert.equal(path.file, 'te.st');
+        assert.equal(path.full, opts.path + '/t/e/-/te.st');
+        assert.equal(path.rel, 't/e/-/te.st');
+      });
+
+      it('uses short direcory structure for short module name', function () {
+        var path = cache.getPath('http://registry/q');
+        assert.equal(path.dir, opts.path + '/q');
+        assert.equal(path.file, 'q');
+        assert.equal(path.full, opts.path + '/q/q');
+        assert.equal(path.rel, 'q/q');
+      });
+
+      it('cuts the version suffix and file extension from short module names', function () {
+        var path = cache.getPath('http://registry/q-1.2.3.tgz');
+        assert.equal(path.dir, opts.path + '/q');
+        assert.equal(path.file, 'q-1.2.3.tgz');
+        assert.equal(path.full, opts.path + '/q/q-1.2.3.tgz');
+        assert.equal(path.rel, 'q/q-1.2.3.tgz');
+      });
+    });
   });
 
 });

--- a/test/cache.js
+++ b/test/cache.js
@@ -129,18 +129,18 @@ describe('cache', function() {
 
       it('uses short direcory structure for short module name', function () {
         var path = cache.getPath('http://registry/q');
-        assert.equal(path.dir, opts.path + '/q');
+        assert.equal(path.dir, opts.path + '/q/-/-');
         assert.equal(path.file, 'q');
-        assert.equal(path.full, opts.path + '/q/q');
-        assert.equal(path.rel, 'q/q');
+        assert.equal(path.full, opts.path + '/q/-/-/q');
+        assert.equal(path.rel, 'q/-/-/q');
       });
 
       it('cuts the version suffix and file extension from short module names', function () {
         var path = cache.getPath('http://registry/q-1.2.3.tgz');
-        assert.equal(path.dir, opts.path + '/q');
+        assert.equal(path.dir, opts.path + '/q/-/-');
         assert.equal(path.file, 'q-1.2.3.tgz');
-        assert.equal(path.full, opts.path + '/q/q-1.2.3.tgz');
-        assert.equal(path.rel, 'q/q-1.2.3.tgz');
+        assert.equal(path.full, opts.path + '/q/-/-/q-1.2.3.tgz');
+        assert.equal(path.rel, 'q/-/-/q-1.2.3.tgz');
       });
     });
   });


### PR DESCRIPTION
Suggests a solution for #10 by adding a new command-line parameter:

    -f, --friendly-names  Use actual file names instead of hashes in the cache

which makes storing the `test-1.2.3.tgz` module like this:

    t/e/s/test-1.2.3.tgz