### PR TITLE
Fix for error message

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -90,7 +90,7 @@ exports.handler = function(req, res) {
       if (!err && response.statusCode === 200) {
         var file = cache.write(dest);
         r.pipe(file);
-        r.pipe(res);
+        r.pipe(res, {end: false});
 
       } else {
         // serve expired cache if user wants so


### PR DESCRIPTION
When proxy:ing https content some pretty ominous error messages are printed out
```
$ ./npm-proxy-cache --storage ../doh/ --friendly-names; npm  --proxy http://localhost:8080 --https-proxy http://localhost:8080 --strict-ssl false i wrappy
[2015-06-07 20:38:00.777] [INFO] proxy - Listening on localhost:8080 [26595]
[2015-06-07 20:38:15.600] [WARN] proxy - direct http://registry.npmjs.org/wrappy
[2015-06-07 20:38:16.239] [ERROR] proxy - > ERR: [object Object]
[2015-06-07 20:38:16.248] [ERROR] proxy - < ERR: [object Object]
[2015-06-07 20:38:16.250] [ERROR] proxy - > ERR: [object Object]
```
My take is that these are caused by npm-proxy-cache closing the socket npm has opened before npm is done with sending all data. This PR fixes this behaviour.
