### PR TITLE
Integrated support for running on Windows 

### DIFF
--- a/bin/npm-proxy-cache
+++ b/bin/npm-proxy-cache
@@ -19,6 +19,7 @@ program
   .option('-f, --friendly-names', 'Use actual file names instead of hashes in the cache')
   .option('-v, --verbose', 'Verbose mode')
   .option('-l, --log-path [path]', 'Log path')
+  .option('-m, --mitmport [port]', 'HTTPs port to use instead of MITM (necessary for running on Windows systems)')
   .parse(process.argv);
 
 require('../lib/proxy').powerup(program);

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -45,10 +45,17 @@ exports.powerup = function(opts) {
     log4js.addAppender(log4js.appenders.file(opts.logPath), 'proxy');
   }
 
-  // make sure there's no previously created socket
-  if (fs.existsSync(mitmSocketPath))
-    fs.unlinkSync(mitmSocketPath);
 
+  if(!opts.mitmport){
+    // make sure there's no previously created socket
+    if (fs.existsSync(mitmSocketPath))
+        fs.unlinkSync(mitmSocketPath);
+  } else {
+    // replace mitm socket path with port
+    // this is necessary on Windows, otherwise it will not work (MITM not supported)
+    mitmSocketPath = opts.mitmport;
+  }
+  
   // fake https server, MITM if you want
   https.createServer(options, this.handler).listen(mitmSocketPath);
 


### PR DESCRIPTION
Added support for running on Windows using the -m parameter (overrides mitm socket path)
Issue described here: https://github.com/runk/npm-proxy-cache/issues/6
Fix based on solution proposed by @wilmveel and @nalbion

Usage example:
`npm-proxy-cache -m 9000 -p 8080`

It basically overrides the mitm socket if the `-m` or `--mitmport` option is specified at the command line. This resolves the issue with running it on Windows systems