### PR TITLE
Don't leave a hanging pipe

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -110,9 +110,13 @@ exports.handler = function(req, res) {
       // don't save responses with codes other than 200
       if (!err && response.statusCode === 200) {
         var file = cache.write(dest);
-        r.pipe(file);
-        r.pipe(res, {end: false});
-
+        r.pipe(file).on('finish', function() {
+          cache.meta(dest, function(err, meta){
+            if (err)
+              throw err;
+            respondWithCache(dest, cache, meta, res);
+          });
+        });
       } else {
         // serve expired cache if user wants so
         if (exports.opts.expired && meta.status === Cache.EXPIRED)


### PR DESCRIPTION
Proposal for Issue #29 

Previous commit 5e7c52ece87aa6f6ac5972a908691a7bcbc32877 caused an issue which
greatly slowed direct downloads.

Because the commit disabled the 'end' event on the socket, it would wait until
the socket timed out before continuing.

This change will instead pipe the direct download into the cache before then
attempting to re-read and send the cached copy through the pipe, which does
not disable the 'end' event.

A nicer solution would be pipe to both the file and the socket simultaneously
but I could not figure out how to support both without regressing the
write-on-closed-socket issue mentioned above.
