### PR TITLE
using req.connection.encrypted to check for https protocol

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -83,7 +83,7 @@ exports.httpHandler = function(req, res) {
   var cache = exports.cache,
     log = exports.log,
     path = url.parse(req.url).path,
-    schema = Boolean(req.client.pair) ? 'https' : 'http',
+    schema = req.client.pair || req.connection.encrypted ? 'https' : 'http',
     dest = schema + '://' + req.headers['host'] + path;
 
   var params = {


### PR DESCRIPTION
Not sure why you needed the `Boolean()` wrapper so I removed it and let the coercion do its job