### PR TITLE
Prevent cycles when forwarding requests

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -22,6 +22,8 @@ exports.opts = {};
 // Port or socket path of internal MITM server.
 var mitmAddress;
 
+// Random header to prevent sending requests in a cycle
+var cycleCheckHeader = 'x-npm-proxy-cache-' + Math.round(Math.random() * 10000)
 
 exports.powerup = function(opts) {
 
@@ -86,11 +88,19 @@ exports.httpHandler = function(req, res) {
     schema = req.client.pair || req.connection.encrypted ? 'https' : 'http',
     dest = schema + '://' + req.headers['host'] + path;
 
+  if (req.headers[cycleCheckHeader]) {
+    res.writeHead(502)
+    res.end('Sending requests to myself. Stopping to prevent cycles.')
+    return
+  }
+
   var params = {
     headers: {},
     rejectUnauthorized: false,
     url: dest
   };
+
+  params.headers[cycleCheckHeader] = 1
 
   // Carry following headers down to dest npm repository.
   var carryHeaders = ['authorization', 'version', 'referer', 'npm-session', 'user-agent'];


### PR DESCRIPTION
Closes #48

This commit adds a random header "x-npm-proxy-cache-<random number>"
to each requests send to the registry. It also rejects requests
with this header.
This is done to prevent "curl http://localhost:8080" from sending
the npm-proxy-cache into and endless loop of message-forwards.