### PR TITLE
Feature/dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+node_modules
+*.md
+test
+.git*
+cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM mhart/alpine-node
+
+ADD package.json /tmp/package.json
+
+RUN cd /tmp && \
+    npm install --production && \
+    mkdir -p /opt/npm-proxy-cache && \
+    cp -a /tmp/node_modules /opt/npm-proxy-cache && \
+    mkdir -p /opt/npm-proxy-cache/cache
+
+VOLUME /opt/npm-proxy-cache/cache
+
+WORKDIR /opt/npm-proxy-cache
+ADD . /opt/npm-proxy-cache
+
+# Expose API port
+EXPOSE 8080
+
+ENTRYPOINT ["node", "/opt/npm-proxy-cache/bin/npm-proxy-cache"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM mhart/alpine-node
 
+MAINTAINER Dmitry Shirokov <deadrunk@gmail.com>
+
 ADD package.json /tmp/package.json
 
 RUN cd /tmp && \

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ overriden using command line options:
         -m, --internal-port   HTTPs port to use for internal proxying "MITM" server (necessary for running on Windows systems)
         --help                This help
 
+## Docker
+
+The docker image of this repository is not hosted on Docker Hub (yet)
+
+To run npm-proxy-cache as a Docker container, you need to build the image first:
+
+`docker build -t npm-proxy-cache .`
+
+After building the image successfully, you can run the Docker container. To pass parameters, simply append them to the `docker run` command, like so:
+
+`docker run -t npm-proxy-cache --port 8080 --host 0.0.0.0 --expired`
 
 ## Why can't I use the built-in npm cache?
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,19 @@ more work and maintenance.
 
 
 ## Installation
-
+### NPM
     npm install npm-proxy-cache -g
 
+### Docker
+The docker image of this repository is not hosted on Docker Hub (yet)
+
+To run npm-proxy-cache as a Docker container, you need to build the image first:
+
+`docker build -t npm-proxy-cache .`
+
+After building the image successfully, you can run the Docker container. To pass parameters, simply append them to the `docker run` command, like so:
+
+`docker run -t npm-proxy-cache --port 8080 --host 0.0.0.0 --expired`
 
 ## Usage
 
@@ -55,18 +65,6 @@ overriden using command line options:
         -l, --log-path        Log path
         -m, --internal-port   HTTPs port to use for internal proxying "MITM" server (necessary for running on Windows systems)
         --help                This help
-
-## Docker
-
-The docker image of this repository is not hosted on Docker Hub (yet)
-
-To run npm-proxy-cache as a Docker container, you need to build the image first:
-
-`docker build -t npm-proxy-cache .`
-
-After building the image successfully, you can run the Docker container. To pass parameters, simply append them to the `docker run` command, like so:
-
-`docker run -t npm-proxy-cache --port 8080 --host 0.0.0.0 --expired`
 
 ## Why can't I use the built-in npm cache?
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+npmproxycache:
+    build: .
+    ports:
+      - "8080:8080"
+    # You can pass parameters here
+    command: "--host 0.0.0.0 --port 8080 --verbose --expired"


### PR DESCRIPTION
Fixes #46 

Adding the `Dockerfile` and a `docker-compose.yml` example file.

@runk can you host the Docker image on `Docker Hub`? Then it will be associated with your name `runk/npm-proxy-cache`