### PR TITLE
provide callback to fix: The "listener" argument must be of type Func…

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -12,7 +12,7 @@ function Cache(opts) {
   this.opts.path = opts.path || path.join(__dirname, '/../cache');
 
   this.locks = {};
-
+  var nop = function() {};
 
   this.stat = function(fullpath) {
     if (!fs.existsSync(fullpath))
@@ -55,7 +55,7 @@ function Cache(opts) {
     var path = this.getPath(key),
       file = fs.createReadStream(path.full);
     file.on('finish', function() {
-      file.close();
+      file.close(nop);
     });
 
     return file;
@@ -75,7 +75,7 @@ function Cache(opts) {
     file.on('finish', function() {
       // release lock
       delete (locks[key]);
-      file.close();
+      file.close(nop);
     });
 
     return file;


### PR DESCRIPTION
node9.2.0 (installed using nodeenv --prebuilt on ubuntu16.04.3):
```js
[2017-11-23 17:05:51.345] [WARN] proxy - direct https://registry.npmjs.org:443/bower
events.js:180
    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'listener', 'Function');
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "listener" argument must be of type Function
    at _addListener (events.js:180:11)
    at WriteStream.addListener (events.js:240:10)
    at WriteStream.close (fs.js:2302:10)
    at WriteStream.<anonymous> (/var/cache/npm/node_modules/npm-proxy-cache/lib/cache.js:78:12)
    at WriteStream.emit (events.js:164:20)
    at finishMaybe (_stream_writable.js:605:14)
    at afterWrite (_stream_writable.js:456:3)
    at onwrite (_stream_writable.js:446:7)
    at fs.js:2246:5
```